### PR TITLE
Add flaxmodels to "New Libraries".

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ This section contains libraries that are well-made and useful, but have not nece
 - [delta PV](https://github.com/romanodev/deltapv) - A photovoltaic simulator with automatic differentation. <img src="https://img.shields.io/github/stars/romanodev/deltapv?style=social" align="center">
 - [jaxlie](https://github.com/brentyi/jaxlie) - Lie theory library for rigid body transformations and optimization. <img src="https://img.shields.io/github/stars/brentyi/jaxlie?style=social" align="center">
 - [BRAX](https://github.com/google/brax) - Differentiable physics engine to simulate environments along with learning algorithms to train agents for these environments. <img src="https://img.shields.io/github/stars/google/brax?style=social" align="center">
+- [flaxmodels](https://github.com/matthias-wright/flaxmodels) - Pretrained models for Jax/Flax. <img src="https://img.shields.io/github/stars/matthias-wright/flaxmodels?style=social" align="center">
 
 <a name="models-and-projects" />
 


### PR DESCRIPTION
Flaxmodels is a package containing pretrained models for Jax/Flax. Currently we have StyleGAN2, GPT2, VGG{16,19}, and ResNet{18, 34, 50, 101, 152}.