### PR TITLE
request to link to exojax in awesome-jax list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,7 @@ This section contains libraries that are well-made and useful, but have not nece
 - [BRAX](https://github.com/google/brax) - Differentiable physics engine to simulate environments along with learning algorithms to train agents for these environments. <img src="https://img.shields.io/github/stars/google/brax?style=social" align="center">
 - [flaxmodels](https://github.com/matthias-wright/flaxmodels) - Pretrained models for Jax/Flax. <img src="https://img.shields.io/github/stars/matthias-wright/flaxmodels?style=social" align="center">
 - [CR.Sparse](https://github.com/carnotresearch/cr-sparse) - XLA accelerated algorithms for sparse representations and compressive sensing. <img src="https://img.shields.io/github/stars/carnotresearch/cr-sparse?style=social" align="center">
+- [exojax](https://github.com/HajimeKawahara/exojax) - Automatic differentiable spectrum modeling of exoplanets/brown dwarfs compatible to JAX. <img src="https://img.shields.io/github/stars/HajimeKawahara/exojax?style=social" align="center">
 
 <a name="models-and-projects" />
 


### PR DESCRIPTION
We made a package for an auto-differentiable spectral model for exoplanets/brown dwarfs. I hope you include exojax in the awesome-jax list. 

- [paper under review](https://arxiv.org/abs/2105.14782)
- [documentation](http://secondearths.sakura.ne.jp/exojax/) including API and tutorials. 
- exojax contains opacity computation and radiative transfer with auto-diff. 
- HITRAN/HITEMP and ExoMOL are available as molecular databases

