### PR TITLE
Add implementation of gMLP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ This section contains libraries that are well-made and useful, but have not nece
 - [Normalizer-Free Networks](https://github.com/deepmind/deepmind-research/tree/master/nfnets) - Official Haiku implementation of [NFNets](https://arxiv.org/abs/2102.06171).
 - [Distributed Shampoo](https://github.com/google-research/google-research/tree/master/scalable_shampoo) - Implementation of [Second Order Optimization Made Practical](https://arxiv.org/abs/2002.09018).
 - [JAX (Flax) RL](https://github.com/ikostrikov/jax-rl) - Implementations of reinforcement learning algorithms.
+- [gMLP](https://github.com/SauravMaheshkar/gMLP) - Implementation of [Pay Attention to MLPs](https://arxiv.org/abs/2105.08050).
 
 <a name="videos" />
 


### PR DESCRIPTION
Adds own [implementation](https://github.com/SauravMaheshkar/gMLP) of gMLP from [Pay Attention to MLPs](https://arxiv.org/abs/2105.08050).