### PR TITLE
Added `jaxdf` to New Libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ This section contains libraries that are well-made and useful, but have not nece
 - [JAXopt](https://github.com/google/jaxopt) - Hardware accelerated (GPU/TPU), batchable and differentiable optimizers in JAX. <img src="https://img.shields.io/github/stars/google/jaxopt?style=social" align="center">
 - [PIX](https://github.com/deepmind/dm_pix) - PIX is an image processing library in JAX, for JAX. <img src="https://img.shields.io/github/stars/deepmind/dm_pix?style=social" align="center">
 - [bayex](https://github.com/alonfnt/bayex) - Bayesian Optimization powered by JAX. <img src="https://img.shields.io/github/stars/alonfnt/bayex?style=social" align="center">
+- [JaxDF](https://github.com/ucl-bug/jaxdf) - Framework for differentiable simulators with arbitrary discretizations. <img src="https://img.shields.io/github/stars/ucl-bug/jaxdf?style=social" align="center">
 
 <a name="models-and-projects" />
 


### PR DESCRIPTION
Added our newborn library for writing linear and non-linear operators in jax with arbitrary discretizations, [see here](https://ucl-bug.github.io/jaxdf/)
It is still in active development, but I hope it matches the spirit of the list!