### PR TITLE
Add JAX-tqdm to New-Libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ This section contains libraries that are well-made and useful, but have not nece
 - [JAXFit](https://github.com/dipolar-quantum-gases/jaxfit) - Accelerated curve fitting library for nonlinear least-squares problems (see [arXiv paper](https://arxiv.org/abs/2208.12187)). <img src="https://img.shields.io/github/stars/dipolar-quantum-gases/jaxfit?style=social" align="center">
 - [econpizza](https://github.com/gboehl/econpizza) - Solve macroeconomic models with hetereogeneous agents using JAX. <img src="https://img.shields.io/github/stars/gboehl/econpizza?style=social" align="center">
 - [SPU](https://github.com/secretflow/spu) - A domain-specific compiler and runtime suite to run JAX code with MPC(Secure Multi-Party Computation). <img src="https://img.shields.io/github/stars/secretflow/spu?style=social" align="center">
+- [jax-tqdm](https://github.com/jeremiecoullon/jax-tqdm) - Add a tqdm progress bar to JAX scans and loops. <img src="https://img.shields.io/github/stars/jeremiecoullon/jax-tqdm?style=social" align="center">
 
 <a name="models-and-projects" />
 


### PR DESCRIPTION
This is a small utility library to allow [tqdm](https://github.com/tqdm/tqdm) progress bars to be added to JAX scans and loops. Thought it might be handy (I am one of the maintainers) for people.