### PR TITLE
Added `kernex` for differentiable stencil computation.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ This section contains libraries that are well-made and useful, but have not nece
 - [econpizza](https://github.com/gboehl/econpizza) - Solve macroeconomic models with hetereogeneous agents using JAX. <img src="https://img.shields.io/github/stars/gboehl/econpizza?style=social" align="center">
 - [SPU](https://github.com/secretflow/spu) - A domain-specific compiler and runtime suite to run JAX code with MPC(Secure Multi-Party Computation). <img src="https://img.shields.io/github/stars/secretflow/spu?style=social" align="center">
 - [jax-tqdm](https://github.com/jeremiecoullon/jax-tqdm) - Add a tqdm progress bar to JAX scans and loops. <img src="https://img.shields.io/github/stars/jeremiecoullon/jax-tqdm?style=social" align="center">
-
+- [Kernex](https://github.com/ASEM000/kernex) - Differentiable stencil decorators in JAX.
 <a name="models-and-projects" />
 
 ## Models and Projects


### PR DESCRIPTION
Added `kernex`, a new package offers `kmap` and `kscan` decorators that offers stencil computation based on `jax.vmap` and `jax.lax.scan`

Example for convolution operation 

```python
import jax
import jax.numpy as jnp
import kernex as kex

@jax.jit
@kex.kmap(
    kernel_size= (3,3,3),
    padding = ('valid','same','same'))
def kernex_conv2d(x,w):
    # JAX channel first conv2d with 3x3x3 kernel_size 
    return jnp.sum(x*w)
```
