### PR TITLE
Add `safejax` in the "New Libraries" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ This section contains libraries that are well-made and useful, but have not nece
 - [econpizza](https://github.com/gboehl/econpizza) - Solve macroeconomic models with hetereogeneous agents using JAX. <img src="https://img.shields.io/github/stars/gboehl/econpizza?style=social" align="center">
 - [SPU](https://github.com/secretflow/spu) - A domain-specific compiler and runtime suite to run JAX code with MPC(Secure Multi-Party Computation). <img src="https://img.shields.io/github/stars/secretflow/spu?style=social" align="center">
 - [jax-tqdm](https://github.com/jeremiecoullon/jax-tqdm) - Add a tqdm progress bar to JAX scans and loops. <img src="https://img.shields.io/github/stars/jeremiecoullon/jax-tqdm?style=social" align="center">
+- [safejax](https://github.com/alvarobartt/safejax) - Serialize JAX, Flax, Haiku, or Objax model params with 🤗`safetensors`. <img src="https://img.shields.io/github/stars/alvarobartt/safejax?style=social" align="center">
 
 <a name="models-and-projects" />
 


### PR DESCRIPTION
[`safejax`](https://github.com/alvarobartt/safejax) is a Python package I developed around [🤗`safetensors`](https://github.com/huggingface/safetensors) which is a safe format for storing tensors as opposed to [`pickle`]() which is not safe, as well as some other improvements and/or differences compared to the rest of the tensor storing approaches out there.

So on, I built `safejax` to combine `safetensors` with a flattening/unflattening approach to store the JAX arrays as well as the tree itself. This both serialization of model parameters (weights) as well as its later load (deserialization).