### PR TITLE
Add Lorax to README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,7 @@ This section contains libraries that are well-made and useful, but have not nece
 - [jax-tqdm](https://github.com/jeremiecoullon/jax-tqdm) - Add a tqdm progress bar to JAX scans and loops. <img src="https://img.shields.io/github/stars/jeremiecoullon/jax-tqdm?style=social" align="center">
 - [safejax](https://github.com/alvarobartt/safejax) - Serialize JAX, Flax, Haiku, or Objax model params with 🤗`safetensors`. <img src="https://img.shields.io/github/stars/alvarobartt/safejax?style=social" align="center">
 - [Kernex](https://github.com/ASEM000/kernex) - Differentiable stencil decorators in JAX.
+- [Lorax](https://github.com/davisyoshida/lorax) - Automatically apply LoRA to JAX models (Flax, Haiku, etc.)
 
 <a name="models-and-projects" />
 


### PR DESCRIPTION
I added Lorax, which transforms JAX functions (or models) into ones which use [LoRA](https://arxiv.org/abs/2106.09685)