### PR TITLE
Added DeepSeek-R1 Flax Distill to README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,7 @@ This section contains libraries that are well-made and useful, but have not nece
 
 ### Flax
 
+- [DeepSeek-R1-Flax-1.5B-Distill](https://github.com/J-Rosser-UK/Torch2Jax-DeepSeek-R1-Distill-Qwen-1.5B) - Flax implementation of DeepSeek-R1 1.5B distilled reasoning LLM.
 - [Performer](https://github.com/google-research/google-research/tree/master/performer/fast_attention/jax) - Flax implementation of the Performer (linear transformer via FAVOR+) architecture.
 - [JaxNeRF](https://github.com/google-research/google-research/tree/master/jaxnerf) - Implementation of [_NeRF: Representing Scenes as Neural Radiance Fields for View Synthesis_](http://www.matthewtancik.com/nerf) with multi-device GPU/TPU support.
 - [mip-NeRF](https://github.com/google/mipnerf) - Official implementation of [_Mip-NeRF: A Multiscale Representation for Anti-Aliasing Neural Radiance Fields_](https://jonbarron.info/mipnerf).


### PR DESCRIPTION
Added new repo to "Flax" section for DeepSeek-R1.

To my knowledge this is the first OpenSource implementation of a reasoning model in Jax!