### PR TITLE
Add MBIRJAX

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,8 @@ This section contains libraries that are well-made and useful, but have not nece
 - [DiffeRT](https://github.com/jeertmans/DiffeRT) - Differentiable Ray Tracing toolbox for Radio Propagation powered by the JAX ecosystem. <img src="https://img.shields.io/github/stars/jeertmans/DiffeRT?style=social" align="center">
 - [JAX-in-Cell](https://github.com/uwplasma/JAX-in-Cell) - Plasma physics simulations using a PIC (Particle-in-Cell) method to self-consistently solve for electron and ion dynamics in electromagnetic fields <img src="https://img.shields.io/github/stars/uwplasma/JAX-in-Cell?style=social" align="center">
 - [kvax](https://github.com/nebius/kvax) - A FlashAttention implementation for JAX with support for efficient document mask computation and context parallelism. <img src="https://img.shields.io/github/stars/nebius/kvax?style=social" align="center">
+- [MBIRJAX](https://github.com/cabouman/mbirjax) - High-performance tomographic reconstruction. <img src="https://img.shields.io/github/stars/cabouman/mbirjax?style-social" align="center">
+
 
 
 <a name="models-and-projects" />

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,6 @@ This section contains libraries that are well-made and useful, but have not nece
 - [MBIRJAX](https://github.com/cabouman/mbirjax) - High-performance tomographic reconstruction. <img src="https://img.shields.io/github/stars/cabouman/mbirjax?style-social" align="center">
 
 
-
 <a name="models-and-projects" />
 
 ## Models and Projects


### PR DESCRIPTION
MBIRJAX is a package for CT reconstruction for cone beam and parallel beam data.  It is used for research projects at Oak Ridge National Labs, the Advanced Light Source at Lawrence Berkeley National Labs, and several private companies.  