### PR TITLE
Add bayes-hdc to Libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ This is a curated list of awesome JAX libraries, projects, and other resources. 
 - [Fortuna](https://github.com/awslabs/fortuna) - AWS library for Uncertainty Quantification in Deep Learning. <img src="https://img.shields.io/github/stars/awslabs/fortuna?style=social" align="center">
 - [BlackJAX](https://github.com/blackjax-devs/blackjax) - Library of samplers for JAX. <img src="https://img.shields.io/github/stars/blackjax-devs/blackjax?style=social" align="center">
 - [Dynamax](https://github.com/probml/dynamax) - Probabilistic state space models. <img src="https://img.shields.io/github/stars/probml/dynamax?style=social" align="center">
+- [bayes-hdc](https://github.com/rlogger/bayes-hdc) - Probabilistic hyperdimensional computing and vector symbolic architectures: Gaussian and Dirichlet hypervector types with closed-form moment propagation, end-to-end variational training, conformal prediction sets, and group-theoretic equivariance verifiers. <img src="https://img.shields.io/github/stars/rlogger/bayes-hdc?style=social" align="center">
 
 <a name="new-libraries" />
 


### PR DESCRIPTION
## What this PR adds

Adds [`bayes-hdc`](https://github.com/rlogger/bayes-hdc) to the **Libraries** section, immediately after Dynamax (positioned with the probabilistic / uncertainty-quantification cluster — NumPyro, Fortuna, BlackJAX, Dynamax — which is the closest topical fit).

## What `bayes-hdc` is

A JAX-native library for **hyperdimensional computing (HDC)** and **vector symbolic architectures (VSA)** with a built-in probabilistic layer (PVSA):

- 8 classical VSA models — BSC, MAP, HRR, FHRR, BSBC, CGR, MCR, VTB — under a uniform pytree-native API.
- `GaussianHV` and `DirichletHV` distributional hypervector types with closed-form moment propagation under `bind`, `bundle`, `permute`, and `cleanup`.
- End-to-end **variational codebook training** via reparameterisation gradients and a minimal `lax.scan`-compiled Adam loop.
- **Split-conformal prediction sets** with finite-sample coverage guarantees (Romano et al. 2020).
- **Group-theoretic equivariance verifiers** for the cyclic-shift action of `Z/d`.

To my knowledge no other open-source HDC library offers a JAX backend, end-to-end gradient training, or formal coverage guarantees — TorchHD covers PyTorch, hdlib targets bioinformatics on NumPy, NengoSPA is biologically-realistic spiking VSA. `bayes-hdc` fills the JAX / probabilistic / UQ lane.

## Quality signals

- **Tests:** 506 passing, 93 % line coverage on 23 modules.
- **CI:** Ubuntu + macOS × Python 3.9–3.13 on every push.
- **Docs:** Sphinx + Furo, deployed to GitHub Pages, built clean under `-W` (warnings as errors).
- **Lint / format / type checks:** `ruff check`, `ruff format --check`, `mypy bayes_hdc/` all clean.
- **License:** MIT.
- **Hardware:** runs on CPU / GPU / TPU; `pmap` and `shard_map` wrappers degrade gracefully on single-device hosts.
- **Provenance:** every primitive cites a primary HDC/VSA paper; per-paper attribution audit at [`docs/audit/`](https://github.com/rlogger/bayes-hdc/tree/main/docs/audit).

## Awesome-list checklist

- [x] Format matches the existing line style (`- [Name](url) - Description. <stars badge>`).
- [x] Description is one sentence, factual, no marketing language.
- [x] Library is JAX-native (every primitive composes with `jit` / `vmap` / `grad` / `pmap` / `shard_map`).
- [x] Library is actively maintained.
- [x] Library is OSI-licensed (MIT).
- [x] Library has tests, docs, and CI.

Thanks for maintaining this list — it was useful when I was scoping the project.